### PR TITLE
Ensure .ssh directory exists before adding known hosts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,9 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Trust host
-        run: ssh-keyscan -H ${{ secrets.PI_HOST }} >> ~/.ssh/known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H ${{ secrets.PI_HOST }} >> ~/.ssh/known_hosts
 
       - name: Rsync site to Pi
         run: |


### PR DESCRIPTION
## Summary
- Make deploy workflow create `.ssh` folder before appending to `known_hosts`

## Testing
- `python - <<'PY'
import yaml, sys
yaml.safe_load(open('.github/workflows/deploy.yaml'))
print('YAML parsed successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689d04797000832b94053582c9214e3a